### PR TITLE
Fix for POWER9 architecture support

### DIFF
--- a/stoc2det.cpp
+++ b/stoc2det.cpp
@@ -293,9 +293,9 @@ bool st2det::open_files( std::string folder, std::string output, std::string pre
 		printf(" * Detected %d reactions\n", reactions);
 
 	/// step 2: left matrix	
-	char* left_matrix = (char*)  malloc ( sizeof(char)*this->species*reactions );
-	char* right_matrix = (char*) malloc ( sizeof(char)*this->species*reactions );
-	char* var_matrix = (char*)   malloc ( sizeof(char)*this->species*reactions );
+	int* left_matrix = (int*)  malloc ( sizeof(int)*this->species*reactions );
+	int* right_matrix = (int*) malloc ( sizeof(int)*this->species*reactions );
+	int* var_matrix = (int*)   malloc ( sizeof(int)*this->species*reactions );
 
 	leftfile.open( (this->DEFAULT_FOLDER+"/left_side").c_str() );
 	// while ( leftfile.good() ) {


### PR DESCRIPTION
The left_matrix, right_matrix and var_matrix are
currently assigned using `char` as their data type,
but they are created using the `atoi` function, which
returns `int`. These data types are different sizes,
and on POWER9 architecture this was causing memory
corruption.